### PR TITLE
feat: Implement image generation quota with client-side SQLite

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -26,7 +26,13 @@ export async function initDb(): Promise<Database> {
   }
 
   const SQL = await initSqlJs({
-    locateFile: file => `/${file}` // Assuming sql-wasm.wasm will be in the public root
+    locateFile: file => {
+      // Ensure BASE_URL ends with a slash if it's not just '/'
+      const baseUrl = import.meta.env.BASE_URL;
+      const path = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+      console.log(`AuthContext: locateFile path for ${file}: ${path}${file}`);
+      return `${path}${file}`;
+    }
   });
 
   try {


### PR DESCRIPTION
This commit introduces a persistent image generation quota system for you.

Key changes include:

1.  **User Authentication & Quota Logic (`AuthContext.tsx`):**
    *   Integrated Firebase for Google Sign-In.
    *   Implemented a daily image generation quota (default 5 images).
    *   Special user `daruokta@gmail.com` has unlimited generations.
    *   Quota resets daily based on your local date.

2.  **Client-Side Database (`database.ts`, `sql.js`):**
    *   Added `sql.js` to manage an SQLite database in the browser.
    *   Created a `user_image_usage` table to store email, last generation date, and images generated today.
    *   Implemented persistence by saving the database to `localStorage` after changes and loading it on initialization.

3.  **UI Integration (`App.tsx`):**
    *   Displays remaining images for you.
    *   Disables image generation when quota is depleted.
    *   Calls `decrementQuota` context function after successful generation.

4.  **Deployment & Configuration:**
    *   Ensured `vite.config.ts` is configured for GitHub Pages deployment (base path, static asset copying).
    *   `package.json` includes `gh-pages` for deployment.

5.  **Documentation (`README.md`):**
    *   Updated to reflect all new features, tech stack additions (Firebase Auth, sql.js), and the quota system.
    *   Clearly documented the client-side storage mechanism and its limitations (data is browser-specific and can be lost if local storage is cleared).

6.  **Bug Fix (`database.ts`):**
    *   Corrected the loading path for `sql-wasm.wasm` by using `import.meta.env.BASE_URL` in the `locateFile` configuration. This resolves a 404 error that prevented database initialization.

The "Images remaining today" logic is now fixed and persistent within your browser. The application is configured for easy deployment via GitHub Pages.